### PR TITLE
Feature wishlist: expose platformHasNativeSupport, alter getPrefix regex

### DIFF
--- a/src/shortlink.js
+++ b/src/shortlink.js
@@ -24,6 +24,10 @@
         }
     };
 
+    exports.platformHasNativeSupport = function () {
+        return navigator.userAgent.match(/iPhone|iPad|iPod|Android|Dalvik/);
+    };
+
     var MCASH_SHORTLINK_ENDPOINT = 'http://mca.sh/',
         MCASH_SHORTLINK_DEFAULT_PREFIX = 's',
         MCASH_SHORTLINK_RE = /^[a-z]$/,
@@ -38,10 +42,6 @@
         },
         MCASH_DOWNLOAD_IOS = 'https://itunes.apple.com/no/app/mcash/id550136730?mt=8',
         MCASH_DOWNLOAD_ANDROID = 'https://play.google.com/store/apps/details?id=no.mcash',
-
-        platformHasNativeSupport = function () {
-            return navigator.userAgent.match(/iPhone|iPad|iPod|Android|Dalvik/);
-        },
 
         getPrefix = function () {
             var parser,
@@ -256,7 +256,7 @@
 
     exports.displayQRorButton = function () {
         var mCASHDivs = document.getElementsByClassName('mcash-shortlink'),
-            native = platformHasNativeSupport(),
+            native = exports.platformHasNativeSupport(),
             mCASHDiv,
             alternate,
             id,

--- a/src/shortlink.js
+++ b/src/shortlink.js
@@ -49,7 +49,7 @@
                 i;
 
             for (i = 0; i < document.scripts.length; i++) {
-                match = document.scripts[i].src && document.scripts[i].src.match(/^(.*)mcash\.shortlink(\.min)?\.js$/);
+                match = document.scripts[i].src && document.scripts[i].src.match(/^(.*)mcash\.shortlink(.[\.\d]*)?(\.min)?\.js(\?.*)?$/);
                 if (match && match[1]) {
                     parser = document.createElement('a');
                     parser.href = match[1];


### PR DESCRIPTION
Hi!

I'm filing this PR with two suggested changes. 
The unit tests pass with these changes on master. 
The changes have also been tested OK in an application.

**Export the platformHasNativeSupport utility**
With this change consumers of the mcash.shortlink.js library have an easy way
of adapting their application to whether a QR-code or an mCash button will
be displayed to the end-user. This can be useful for instance when the
application should display some kind of help text.

Example use: 

```javascript
const helpMessage = mCASH.platformHasNativeSupport() ?
                'Trykk på mCash-knappen for å fortsette' :
                'Åpne mCash og les QR-koden ved å velge "Handle"';
```

**Change the regexp to allow for different cache busting strategies**
Consumers of the library may want to use different strategies when
upgrading their hosted verison. The regexp before this change forced
consumers to change the path to the library file in order to bust the
browser cache. After this change consumers can use three different
strategies:

	1. /path/to/lib/v0.5.4/mcash.shortlink.min.js, like today
	2. /path/to/lib/mcash.shortlink.0.5.4.min.js
	3. /path/to/lib/mcash.shortlink.min.js?v0.5.4

![mcaschebuster](https://cloud.githubusercontent.com/assets/1223410/16577304/aae5f600-4294-11e6-9f41-172ec0fb519b.PNG)
_Screenshot from https://leaverou.github.io/regexplained/_